### PR TITLE
Upgrade FRR to 7.1 (and change de way it is installed)

### DIFF
--- a/roles/servers/tasks/install_frr_servers.yml
+++ b/roles/servers/tasks/install_frr_servers.yml
@@ -1,14 +1,14 @@
 ---
-- name: Get FRR
-  get_url:
-    url: "{{ item }}"
-    dest: /tmp/
-  with_items: 
-    - https://github.com/FRRouting/frr/releases/download/frr-6.0/frr_6.0-1.ubuntu16.04+1_amd64.deb
-    - https://github.com/FRRouting/frr/releases/download/frr-6.0/frr-pythontools_6.0-1.ubuntu16.04+1_all.deb
-      #- https://github.com/FRRouting/frr/releases/download/frr-6.0/frr_6.0-1.ubuntu18.04+1_amd64.deb
-      #- https://github.com/FRRouting/frr/releases/download/frr-6.0/frr-pythontools_6.0-1.ubuntu18.04+1_all.deb
-  when: "'servers' in group_names"
+#- name: Get FRR
+#  get_url:
+#    url: "{{ item }}"
+#    dest: /tmp/
+#  with_items: 
+#    - https://github.com/FRRouting/frr/releases/download/frr-6.0/frr_6.0-1.ubuntu16.04+1_amd64.deb
+#    - https://github.com/FRRouting/frr/releases/download/frr-6.0/frr-pythontools_6.0-1.ubuntu16.04+1_all.deb
+#      #- https://github.com/FRRouting/frr/releases/download/frr-6.0/frr_6.0-1.ubuntu18.04+1_amd64.deb
+#      #- https://github.com/FRRouting/frr/releases/download/frr-6.0/frr-pythontools_6.0-1.ubuntu18.04+1_all.deb
+#  when: "'servers' in group_names"
 
 - name: Install dependencies
   apt:
@@ -21,10 +21,29 @@
     - python-ipaddr
   when: "'servers' in group_names"
 
-- name: Install FRR
+  #- name: Install FRR
+  #  apt:
+  #    deb: "/tmp/{{ item }}"
+  #  with_items:
+  #    - frr_6.0-1.ubuntu16.04+1_amd64.deb
+  #    - frr-pythontools_6.0-1.ubuntu16.04+1_all.deb
+  #  when: "'servers' in group_names"
+
+# New way to install now that FRR has deb repo
+- name: Add an FRR repo signing key
+  apt_key:
+    url: https://deb.frrouting.org/frr/keys.asc
+    state: present
+
+- name: Add the FRR repo
+  apt_repository:
+    repo: "deb https://deb.frrouting.org/frr {{ ansible_distribution_release }} frr-stable"
+    state: present
+
+- name: Actually install FRR from the repo
   apt:
-    deb: "/tmp/{{ item }}"
+    name: "{{ item }}"
+    update_cache: yes
   with_items:
-    - frr_6.0-1.ubuntu16.04+1_amd64.deb
-    - frr-pythontools_6.0-1.ubuntu16.04+1_all.deb
-  when: "'servers' in group_names"
+    - frr
+    - frr-pythontools

--- a/roles/servers/tasks/install_frr_servers.yml
+++ b/roles/servers/tasks/install_frr_servers.yml
@@ -1,8 +1,8 @@
 ---
-- name: Get facts about the servers to have access to ansible_distribution_release
-  setup:
-    filter:
-      - "ansible_distribution_release"
+#- name: Get facts about the servers to have access to ansible_distribution_release
+#  setup:
+#    filter:
+#      - "ansible_distribution_release"
 
 #- name: Get FRR
 #  get_url:

--- a/roles/servers/tasks/install_frr_servers.yml
+++ b/roles/servers/tasks/install_frr_servers.yml
@@ -1,4 +1,9 @@
 ---
+- name: Get facts about the servers to have access to ansible_distribution_release
+  setup:
+    filter:
+      - "ansible_distribution_release"
+
 #- name: Get FRR
 #  get_url:
 #    url: "{{ item }}"

--- a/servers.yml
+++ b/servers.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: servers
   become: True
+  gather_facts: True
   roles:
     - servers
     - common


### PR DESCRIPTION
Since version 7, FRR stopped releasing `.deb`.  
We now have to use the new repo `https://deb.frrouting.org/frr` for debian-like distribs.